### PR TITLE
Ignore extract in check mode if folder not created

### DIFF
--- a/tasks/oracle.yml
+++ b/tasks/oracle.yml
@@ -60,6 +60,7 @@
     extra_opts: --strip-components=1
   when: java_download is changed
   notify: restart_services
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Java | Oracle | Setting OpenJDK home
   set_fact:


### PR DESCRIPTION
# Pull Request Template

## Description

When in check mode, the extract task can fail if we're in check mode and folder is not yet created

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test Oracle install

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules